### PR TITLE
Minor mod to override ENTRYPOINT

### DIFF
--- a/src/main/scala/dxWDL/RunnerTask.scala
+++ b/src/main/scala/dxWDL/RunnerTask.scala
@@ -184,7 +184,7 @@ object RunnerTask {
                 val DX_HOME = Utils.DX_HOME
                 val dockerRunPath = getMetaDir().resolve("script.submit")
                 val dockerRunScript = s"""|#!/bin/bash -ex
-                                          |dx-docker run -v ${DX_HOME}:${DX_HOME} ${imgName} /bin/bash $${HOME}/execution/meta/script""".stripMargin.trim
+                                          |dx-docker run --entrypoint /bin/bash -v ${DX_HOME}:${DX_HOME} ${imgName} $${HOME}/execution/meta/script""".stripMargin.trim
                 System.err.println(s"writing docker run script to ${dockerRunPath}")
                 Utils.writeFileContent(dockerRunPath, dockerRunScript)
                 dockerRunPath.toFile.setExecutable(true)


### PR DESCRIPTION
Hi @orodeh, something we can discuss at your leisure. Since it doesn't appear that WDL handles / uses Docker's ENTRYPOINT in a particular way, this mod overrides any user-specified ENTRYPOINT to properly run a command within the container.   @mlin and I discussed this earlier today, and I tested it out.